### PR TITLE
Fix duplicated semicolon

### DIFF
--- a/src/SaveMeso.js
+++ b/src/SaveMeso.js
@@ -28,7 +28,7 @@ const SaveMeso = ({ meso, setMeso, mesoName, setMesoName, mesoWeeks, setMesoWeek
             for (let week = 1; week <= Number(mesoWeeks); week++) {
                 meso.days.forEach(day => {
                     const deepCopiedDay = deepCopy(day);
-                    replicatedDays.push({ ...deepCopiedDay, week, completed: false });;
+                    replicatedDays.push({ ...deepCopiedDay, week, completed: false });
                 });
             }
     


### PR DESCRIPTION
## Summary
- remove an extraneous semicolon in `SaveMeso.js`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431ad40990832fb0d77e5cfdc389c8