### PR TITLE
Fix mesocycle list sorting side effects

### DIFF
--- a/src/MesoList.js
+++ b/src/MesoList.js
@@ -112,7 +112,7 @@ const MesoList = ({ userId }) => {
     mesocycles.forEach(meso => adjustTextAreaHeight(meso.id));
   }, [notes, mesocycles]);
 
-  let displayedMesocycles = mesocycles;
+  let displayedMesocycles = [...mesocycles];
 
   if (searchTerm) {
     displayedMesocycles = displayedMesocycles.filter(meso => meso.name.toLowerCase().includes(searchTerm.toLowerCase()));


### PR DESCRIPTION
## Summary
- avoid mutating `mesocycles` list when searching or sorting

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425715b0e8832f9815cf082d9b221a